### PR TITLE
Fix condition flip in Shut the Box

### DIFF
--- a/src/tel/discord/rtab/minigames/ShutTheBox.java
+++ b/src/tel/discord/rtab/minigames/ShutTheBox.java
@@ -247,7 +247,7 @@ public class ShutTheBox implements MiniGame {
 	
 	public String getBotStrategy(int roll, boolean dbl) {
 		if (roll == 1) {
-			if (closedSpaces[0])
+			if (!closedSpaces[0])
 				return " 1";
 			else return null;
 		}


### PR DESCRIPTION
Try this for now. If the problem persists, then the problem is in the for loop, since the first if statement in it throws my custom error on purpose if true.