### PR TITLE
Bomb Roulette minor cosmetic change

### DIFF
--- a/src/tel/discord/rtab/minigames/BombRoulette.java
+++ b/src/tel/discord/rtab/minigames/BombRoulette.java
@@ -118,7 +118,7 @@ public class BombRoulette implements MiniGame {
                     hasJoker = true;
                 break;
                 case BANKRUPT:
-                    output.add("**BANKRUPT**");
+                    output.add("Oh no, you've gone **BANKRUPT**!");
                     score = 0;
                     
                     if (cashSpaces == 0) {


### PR DESCRIPTION
Landing on Bankrupt is now consistent with landing on other non-cash spaces (as opposed to just having the bolded word "BANKRUPT" by itself).